### PR TITLE
Fix xmllint not found when tests fail in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,6 +36,7 @@ jobs:
           include_passed: true
           report_paths: '**/TEST-*.xml'
       - name: Install xmllint
+        if: success() || failure()
         run: sudo apt-get update && sudo apt-get install -y libxml2-utils
       - name: Get Unit conversion percentage
         id: conversions-percent


### PR DESCRIPTION
not sure if it being left out was intentional though